### PR TITLE
Adding Link Definition Objects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.coverdata
+.coverrun
+debug
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/.jshintrc
+++ b/.jshintrc
@@ -15,7 +15,7 @@
   "maxdepth": 4,
   "boss": true,
   "eqnull": true,
-  "globalstrict": true,
+  "globalstrict": false,
   "smarttabs": true,
   "browser": true,
   "node": true,

--- a/README.md
+++ b/README.md
@@ -5,16 +5,61 @@ Middleware that adds the [res.links](http://expressjs.com/api#res.links) functio
 
 
 ## Usage
+
 Join the given links to populate the "Link" response header field.
+
 ```javascript
 res.links({
-  next: 'http://api.example.com/users?page=2',
-  last: 'http://api.example.com/users?page=5'
+    next: 'http://api.example.com/users?page=2',
+    last: 'http://api.example.com/users?page=5'
 });
 ```
 
 yields:
+
 ```
 Link: <http://api.example.com/users?page=2>; rel="next", 
       <http://api.example.com/users?page=5>; rel="last"
 ```
+
+This library also works for link definition objects and arrays, allowing one to construct significantly more complex and descriptive link relations.  You can mix and match as needed, plus keep adding to the list of links.
+
+```javascript
+res.links({
+    next: "http://api.example.com/users?page=2",
+    self: "http://api.example.com/users",
+    search: "http://api.example.com/users{?username,firstname,lastname}"
+});
+res.links({
+    last: "http://api.example.com/users?page=5",
+    stylesheet: {
+        href: "http://static.example.com/ss.css",
+        type: "text/css"
+    },
+    up: [
+        "http://api.example.com/"
+    ],
+    service: [
+        {
+            href: "https://api.example.com/auth",
+            method: "post",
+            profile: "/schemas/auth",
+            title: "auth"
+        }
+    ]
+});
+```
+
+results in:
+
+```
+Link: <http://api.example.com/users>; rel="self",
+      <http://api.example.com/users?page=2>; rel="next",
+      <http://api.example.com/users{?username,firstname,lastname}>; rel="search",
+      <http://api.example.com/users?page=5>; rel="last",
+      <http://static.example.com/ss.css>; rel="stylesheet"; type="text/css",
+      <http://api.example.com/>; rel="up",
+      <https://api.example.com/auth>; rel="service"; method="post"; profile="/schemas/auth"; title="auth"
+```
+
+This greatly assists with working with REST level 3 (Hypermedia) APIs and making the resources self-describing.  In fact, the link definition objects are compatible with [JSON Schema for Hypermedia](http://json-schema.org/latest/json-schema-hypermedia.html#rfc.section.5) and [HAL Link Objects](https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5).  It can use the `link-extension` part of the [Web Linking](https://tools.ietf.org/html/rfc5988#section-5) specification.

--- a/lib/links.js
+++ b/lib/links.js
@@ -15,31 +15,53 @@
  * @api public
  */
 
+function makeLink(rel, ldo) {
+  var i, key, keys, result;
+
+  if (typeof ldo === 'string') {
+    return '<' + ldo + '>; rel="' + rel + '"';
+  }
+
+  result = '<' + ldo.href + '>; rel="' + rel + '"';
+  keys = Object.keys(ldo);
+
+  for (i = 0; i < keys.length; i += 1) {
+    key = keys[i];
+
+    if (key !== 'href' && key !== 'rel') {
+      result += '; ' + key + '="' + ldo[key] + '"';
+    }
+  }
+
+  return result;
+}
+
 function addLinks(links) {
   /*jshint validthis:true */
-  var linkHeader;
+  var arr, i, linkHeader, linkIndex, linkRels, rel;
 
   linkHeader = this.getHeader('Link') || '';
+  linkRels = Object.keys(links);
 
-  Object.keys(links).map(function (rel) {
+  for (linkIndex = 0; linkIndex < linkRels.length; linkIndex += 1) {
+    rel = linkRels[linkIndex];
+    arr = links[rel];
+
     // Force to be an array
-    [].concat(links[rel]).forEach(function (ldo) {
+    if (!Array.isArray(arr)) {
+      arr = [
+        arr
+      ];
+    }
+
+    for (i = 0; i < arr.length; i += 1) {
       if (linkHeader) {
         linkHeader += ', ';
       }
 
-      if (typeof ldo === 'string') {
-        linkHeader += '<' + ldo + '>; rel="' + rel + '"';
-      } else {
-        linkHeader += '<' + ldo.href + '>; rel="' + rel + '"';
-        Object.keys(ldo).forEach(function (key) {
-          if (key !== 'href' && key !== 'rel') {
-            linkHeader += '; ' + key + '="' + ldo[key] + '"';
-          }
-        });
-      }
-    });
-  });
+      linkHeader += makeLink(rel, arr[i]);
+    }
+  }
 
   return this.setHeader('Link', linkHeader);
 }

--- a/lib/links.js
+++ b/lib/links.js
@@ -15,21 +15,39 @@
  * @api public
  */
 
-function addLinks (links) {
-  /*jshint validthis:true */
-  var link = this.getHeader('Link') || '';
-  if (link) {
-    link += ', ';
-  }
-  return this.setHeader('Link', link + Object.keys(links).map(function (rel) {
-    return '<' + links[rel] + '>; rel="' + rel + '"';
-  }).join(', '));
+function addLinks(links) {
+    /*jshint validthis:true */
+    var linkHeader;
+    
+    linkHeader = this.getHeader('Link') || '';
+
+    Object.keys(links).map(function (rel) {
+        // Force to be an array
+        [].concat(links[rel]).forEach(function (ldo) {
+            if (linkHeader) {
+                linkHeader += ', ';
+            }
+
+            if (typeof ldo === 'string') {
+                linkHeader += '<' + ldo + '>; rel="' + rel + '"';
+            } else {
+                linkHeader += '<' + ldo.href + '>; rel="' + rel + '"';
+                Object.keys(ldo).forEach(function (key) {
+                    if (key !== 'href' && key !== 'rel') {
+                        linkHeader += '; ' + key + '="' + ldo[key] + '"';
+                    }
+                });
+            }
+        });
+    });
+
+    return this.setHeader('Link', linkHeader);
 }
 
 
 module.exports = function () {
-  return function (req, res, next) {
-    res.links = addLinks.bind(res);
-    next();
-  };
+    return function (req, res, next) {
+        res.links = addLinks.bind(res);
+        next();
+    };
 };

--- a/lib/links.js
+++ b/lib/links.js
@@ -5,10 +5,10 @@
  *
  * Examples:
  *
- *    res.links({
- *      next: 'http://api.example.com/users?page=2',
- *      last: 'http://api.example.com/users?page=5'
- *    });
+ *  res.links({
+ *    next: 'http://api.example.com/users?page=2',
+ *    last: 'http://api.example.com/users?page=5'
+ *  });
  *
  * @param {Object} links
  * @return {ServerResponse}
@@ -16,38 +16,38 @@
  */
 
 function addLinks(links) {
-    /*jshint validthis:true */
-    var linkHeader;
-    
-    linkHeader = this.getHeader('Link') || '';
+  /*jshint validthis:true */
+  var linkHeader;
 
-    Object.keys(links).map(function (rel) {
-        // Force to be an array
-        [].concat(links[rel]).forEach(function (ldo) {
-            if (linkHeader) {
-                linkHeader += ', ';
-            }
+  linkHeader = this.getHeader('Link') || '';
 
-            if (typeof ldo === 'string') {
-                linkHeader += '<' + ldo + '>; rel="' + rel + '"';
-            } else {
-                linkHeader += '<' + ldo.href + '>; rel="' + rel + '"';
-                Object.keys(ldo).forEach(function (key) {
-                    if (key !== 'href' && key !== 'rel') {
-                        linkHeader += '; ' + key + '="' + ldo[key] + '"';
-                    }
-                });
-            }
+  Object.keys(links).map(function (rel) {
+    // Force to be an array
+    [].concat(links[rel]).forEach(function (ldo) {
+      if (linkHeader) {
+        linkHeader += ', ';
+      }
+
+      if (typeof ldo === 'string') {
+        linkHeader += '<' + ldo + '>; rel="' + rel + '"';
+      } else {
+        linkHeader += '<' + ldo.href + '>; rel="' + rel + '"';
+        Object.keys(ldo).forEach(function (key) {
+          if (key !== 'href' && key !== 'rel') {
+            linkHeader += '; ' + key + '="' + ldo[key] + '"';
+          }
         });
+      }
     });
+  });
 
-    return this.setHeader('Link', linkHeader);
+  return this.setHeader('Link', linkHeader);
 }
 
 
 module.exports = function () {
-    return function (req, res, next) {
-        res.links = addLinks.bind(res);
-        next();
-    };
+  return function (req, res, next) {
+    res.links = addLinks.bind(res);
+    next();
+  };
 };

--- a/test/links.test.js
+++ b/test/links.test.js
@@ -4,76 +4,76 @@ var assert = require('chai').assert;
 var sinon = require('sinon');
 
 function checkGenerator(links, prev, input, expected) {
-    var res;
+  var res;
 
-    res = {
-        getHeader: sinon.stub().returns(prev),
-        setHeader: sinon.stub()
-    };
+  res = {
+    getHeader: sinon.stub().returns(prev),
+    setHeader: sinon.stub()
+  };
 
-    return function (done) {
-        links(null, res, function () {
-            var args;
+  return function (done) {
+    links(null, res, function () {
+      var args;
 
-            res.links(input);
-            args = res.setHeader.getCall(0).args;
-            assert.equal(args[0], 'Link');
-            assert.equal(args[1], expected);
-            done();
-        });
-    };
+      res.links(input);
+      args = res.setHeader.getCall(0).args;
+      assert.equal(args[0], 'Link');
+      assert.equal(args[1], expected);
+      done();
+    });
+  };
 }
 
 
 describe('links#links', function () {
-    //Create our middleware
-    var links = require('./../lib/links')();
+  //Create our middleware
+  var links = require('./../lib/links')();
 
-    it('adds links method to res object', function (done) {
-        var res = {};
+  it('adds links method to res object', function (done) {
+    var res = {};
 
-        assert.isNotFunction(!res.links);
-        links(null, res, function() {
-            assert.isFunction(res.links);
-            done();
-        });
+    assert.isNotFunction(!res.links);
+    links(null, res, function() {
+      assert.isFunction(res.links);
+      done();
     });
+  });
 
-    it('formats header links correctly', checkGenerator(links, null, {
-        test: 'http://jonatan.nilsson.is'
-    }, '<http://jonatan.nilsson.is>; rel="test"'));
+  it('formats header links correctly', checkGenerator(links, null, {
+    test: 'http://jonatan.nilsson.is'
+  }, '<http://jonatan.nilsson.is>; rel="test"'));
 
-    it('preserves existing links', checkGenerator(links, 'previous', {
-        test: 'http://jonatan.nilsson.is'
-    }, 'previous, <http://jonatan.nilsson.is>; rel="test"'));
+  it('preserves existing links', checkGenerator(links, 'previous', {
+    test: 'http://jonatan.nilsson.is'
+  }, 'previous, <http://jonatan.nilsson.is>; rel="test"'));
 
-    it('works with an array', checkGenerator(links, 'something', {
-        up: [
-            'aaaa',
-            'bbbb'
-        ]
-    }, 'something, <aaaa>; rel="up", <bbbb>; rel="up"'));
+  it('works with an array', checkGenerator(links, 'something', {
+    up: [
+      'aaaa',
+      'bbbb'
+    ]
+  }, 'something, <aaaa>; rel="up", <bbbb>; rel="up"'));
 
-    it('converts objects', checkGenerator(links, 'flowers', {
-        obj: {
-            href: 'required',
-            rel: 'IGNORED!',
-            something: 'blah'
-        }
-    }, 'flowers, <required>; rel="obj"; something="blah"'));
+  it('converts objects', checkGenerator(links, 'flowers', {
+    obj: {
+      href: 'required',
+      rel: 'IGNORED!',
+      something: 'blah'
+    }
+  }, 'flowers, <required>; rel="obj"; something="blah"'));
 
-    it('converts mixed input', checkGenerator(links, null, {
-        one: 'one',
-        two: [
-            'two-1',
-            {
-                href: 'two-2',
-                good: 'yes'
-            }
-        ],
-        three: {
-            href: 'three',
-            profile: '/#three'
-        }
-    }, '<one>; rel="one", <two-1>; rel="two", <two-2>; rel="two"; good="yes", <three>; rel="three"; profile="/#three"'));
+  it('converts mixed input', checkGenerator(links, null, {
+    one: 'one',
+    two: [
+      'two-1',
+      {
+        href: 'two-2',
+        good: 'yes'
+      }
+    ],
+    three: {
+      href: 'three',
+      profile: '/#three'
+    }
+  }, '<one>; rel="one", <two-1>; rel="two", <two-2>; rel="two"; good="yes", <three>; rel="three"; profile="/#three"'));
 });


### PR DESCRIPTION
This lets you specify more than just a URL for Link headers.  It adds support for any additional properties that may be desired to comply with various other standards.  The `README.md` cites sources and shows examples of how this can be done, plus explains why one may want to do this.

Refactored how the tests work into a function that will generate the guts of the test instead of repeating code.  This let me add a few more tests to ensure the new functionality works.

I had to modify `.jslintrc` and `.gitignore` to have the tests pass and to ignore files that were generated by the coverage testing tool.